### PR TITLE
Add IRAM_ATTR as required to interrupt handler on ESP32

### DIFF
--- a/src/boards/mcu/espressif/board.cpp
+++ b/src/boards/mcu/espressif/board.cpp
@@ -81,14 +81,26 @@ extern "C"
 #ifdef ESP32
 	portMUX_TYPE mux = portMUX_INITIALIZER_UNLOCKED;
 #endif
+#if defined(ESP8266)
+	void ICACHE_RAM_ATTR BoardDisableIrq(void)
+#elif defined(ESP32)
+	void IRAM_ATTR BoardDisableIrq(void)
+#else
 	void BoardDisableIrq(void)
+#endif
 	{
 #ifdef ESP32
 		portENTER_CRITICAL(&mux);
 #endif
 	}
 
+#if defined(ESP8266)
+	void ICACHE_RAM_ATTR BoardEnableIrq(void)
+#elif defined(ESP32)
+	void IRAM_ATTR BoardEnableIrq(void)
+#else
 	void BoardEnableIrq(void)
+#endif
 	{
 #ifdef ESP32
 		portEXIT_CRITICAL(&mux);

--- a/src/radio/sx126x/radio.cpp
+++ b/src/radio/sx126x/radio.cpp
@@ -448,7 +448,11 @@ extern "C"
 	PacketStatus_t RadioPktStatus;
 	uint8_t RadioRxPayload[255];
 
+#if defined(ESP32)
+	bool DRAM_ATTR IrqFired = false;
+#else
 	bool IrqFired = false;
+#endif
 
 	bool TimerRxTimeout = false;
 	bool TimerTxTimeout = false;
@@ -1219,8 +1223,10 @@ extern "C"
 		BoardEnableIrq();
 	}
 
-#ifdef ESP8266
+#if defined(ESP8266)
 	void ICACHE_RAM_ATTR RadioOnDioIrq(void)
+#elif defined(ESP32)
+	void IRAM_ATTR RadioOnDioIrq(void)
 #else
 	void RadioOnDioIrq(void)
 #endif


### PR DESCRIPTION
The interrupt handler is correctly marked as ICACHE_RAM_ATTR for ESP8266, but
the equivalent IRAM_ATTR attribute for the handler is missing when compiled
under ESP32. This causes a crash if, for example, an OTA update is performed
while the LoRa radio is active. Fix by adding IRAM_ATTR to the handler itself
and the touched functions as well, when compiling under ESP32.

The "irq fired" flag needs DRAM_ATTR too, in case the sketch runs on an ESP32
with PSRAM, and the flag ends up in SPI-backed RAM.