### PR TITLE
Update radio.cpp

### DIFF
--- a/src/radio/sx126x/radio.cpp
+++ b/src/radio/sx126x/radio.cpp
@@ -814,7 +814,7 @@ void RadioSetRxConfig(RadioModems_t modem, uint32_t bandwidth,
 		// WORKAROUND END
 
 		// Timeout Max, Timeout handled directly in SetRx function
-		RxTimeout = 0xFA0;
+		RxTimeout = 0x380;
 
 		break;
 	}


### PR DESCRIPTION
As explained [here ](https://forum.rakwireless.com/t/rak4631-low-power-lorawan-example-rx-windows/4487/23) it solves two issues : 

- Non-fonctionnal RX2 (which could lead to the impossibilty to join network)
- Over power consumption.

0x380 theoritically gives 14ms (I'm not sure of this point, may need tests).