### PR TITLE
fix radio rx

### DIFF
--- a/src/radio/sx126x/radio.cpp
+++ b/src/radio/sx126x/radio.cpp
@@ -814,7 +814,7 @@ void RadioSetRxConfig(RadioModems_t modem, uint32_t bandwidth,
 		// WORKAROUND END
 
 		// Timeout Max, Timeout handled directly in SetRx function
-		RxTimeout = 0x380; // 0xFA0;
+		RxTimeout = RXTIMEOUT_LORA_MAX;
 
 		break;
 	}
@@ -1032,14 +1032,14 @@ void RadioRx(uint32_t timeout)
 						  IRQ_RADIO_NONE);
 
 	LOG_LIB("RADIO", "RX window timeout = %ld", timeout);
+    // Even Continous mode is selected, put a timeout here
+    if (timeout != 0)
+    {
+        TimerSetValue(&RxTimeoutTimer, timeout);
+        TimerStart(&RxTimeoutTimer);
+    }
 	if (RxContinuous == true)
 	{
-		// Even Continous mode is selected, put a timeout here
-		if (timeout != 0)
-		{
-			TimerSetValue(&RxTimeoutTimer, timeout);
-			TimerStart(&RxTimeoutTimer);
-		}
 		SX126xSetRx(0xFFFFFF); // Rx Continuous
 	}
 	else

--- a/src/radio/sx126x/sx126x.cpp
+++ b/src/radio/sx126x/sx126x.cpp
@@ -270,6 +270,8 @@ void SX126xSetRx(uint32_t timeout)
 
 	SX126xSetOperatingMode(MODE_RX);
 
+    SX126xWriteRegister( REG_RX_GAIN, 0x94 ); // default gain
+
 	buf[0] = (uint8_t)((timeout >> 16) & 0xFF);
 	buf[1] = (uint8_t)((timeout >> 8) & 0xFF);
 	buf[2] = (uint8_t)(timeout & 0xFF);

--- a/src/radio/sx126x/sx126x.h
+++ b/src/radio/sx126x/sx126x.h
@@ -26,9 +26,18 @@
 #define SX1261 1
 #define SX1262 2
 
+
 /*!
-     * Radio complete Wake-up Time with TCXO stabilisation time
-     */
+ * Radio Rx Timeout On Lora MODE, can using platformio.ini change this: -DRXTIMEOUT_LORA_MAX=0xFFFF
+ * RxTimeout = 0x380; // 0xFA0;
+ */
+#ifndef RXTIMEOUT_LORA_MAX
+#define RXTIMEOUT_LORA_MAX 0x380
+#endif
+
+/*!
+ * Radio complete Wake-up Time with TCXO stabilisation time
+ */
 #define RADIO_TCXO_SETUP_TIME 50 // [ms]
 
 /*!


### PR DESCRIPTION
on radio.cpp

- RxTimeout = 0x380;
On LoraMac-node, Using 0xFFFF. so, I added a macro definition, on my project set 0xFFFF is working fine.
- Radio.Rx()
On LoraMac-node, RxTimeoutTimer run on (timeout !=0), not  (RxContinuous == true &&  timeout !=0).

on sx126x.cpp
SX126xSetRx, 'SX126xWriteRegister( REG_RX_GAIN, 0x94 );' add default gain setting,  on my project is working fine.

before this pr,  my device can recv Join-Accept, but can't get any downlink message after that( using TTN, sometimes get a downlink messsage, uplink is working fine) . 
now, No downlink messages will be lost :)

