### PR TITLE
Allow for adjusting control voltage

### DIFF
--- a/src/boards/mcu/board.cpp
+++ b/src/boards/mcu/board.cpp
@@ -69,6 +69,7 @@ uint32_t lora_hardware_init(hw_config hwConfig)
 	_hwConfig.USE_DIO3_ANT_SWITCH = hwConfig.USE_DIO3_ANT_SWITCH; // LORA DIO3 controls antenna (e.g. Insight SIP ISP4520 module)
 	_hwConfig.USE_LDO = hwConfig.USE_LDO;						  // LORA usage of LDO or DCDC power regulator (defaults to DCDC)
 	_hwConfig.USE_RXEN_ANT_PWR = hwConfig.USE_RXEN_ANT_PWR;		  // RXEN used as power for antenna switch
+	_hwConfig.TCXO_CTRL_VOLTAGE = hwConfig.TCXO_CTRL_VOLTAGE;
 
 	TimerConfig();
 

--- a/src/boards/mcu/board.h
+++ b/src/boards/mcu/board.h
@@ -74,6 +74,7 @@ struct hw_config
 	bool USE_DIO3_ANT_SWITCH = false; // Whether DIO2 is used to control the antenna
 	bool USE_LDO = false;			  // Whether SX126x uses LDO or DCDC power regulator
 	bool USE_RXEN_ANT_PWR = false;	  // Whether RX_EN is used as antenna power
+	RadioTcxoCtrlVoltage_t TCXO_CTRL_VOLTAGE = TCXO_CTRL_3_3V;
 };
 
 #ifdef ARDUINO_ARCH_RP2040

--- a/src/radio/sx126x/sx126x.cpp
+++ b/src/radio/sx126x/sx126x.cpp
@@ -92,7 +92,7 @@ void SX126xInit(DioIrqHandler dioIrq)
 	{
 		CalibrationParams_t calibParam;
 
-		SX126xSetDio3AsTcxoCtrl(TCXO_CTRL_3_3V, RADIO_TCXO_SETUP_TIME << 6);
+		SX126xSetDio3AsTcxoCtrl(_hwConfig.TCXO_CTRL_VOLTAGE, RADIO_TCXO_SETUP_TIME << 6);
 		calibParam.Value = 0x7F;
 		SX126xCalibrate(calibParam);
 	}


### PR DESCRIPTION
This allows for adjusting the TCXO control voltage, which 
is not always 3.3V on every board.

The default is kept at 3.3V for compatibility with
previous versions.
