### PR TITLE
Notify confirmed TX failure if datarate becomes insufficient for payl…

### DIFF
--- a/src/mac/LoRaMacHelper.cpp
+++ b/src/mac/LoRaMacHelper.cpp
@@ -410,7 +410,7 @@ static void McpsConfirm(McpsConfirm_t *mcpsConfirm)
 			break;
 		}
 	}
-	if ((mcpsConfirm->Status == LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT) || (mcpsConfirm->Status == LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT))
+	if ((mcpsConfirm->Status == LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT) || (mcpsConfirm->Status == LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT) || (mcpsConfirm->Status == LORAMAC_EVENT_INFO_STATUS_TX_DR_PAYLOAD_SIZE_ERROR))
 	{
 		LoRaMacState &= ~LORAMAC_TX_RUNNING;
 		switch (mcpsConfirm->McpsRequest)


### PR DESCRIPTION
…oad size

When application code requests a confirmed transmission, and the current datarate allows the payload length, the current code will wait a total of 2 groups of 2 RX windows for the confirmation packet. If not received, the code will decrease the TX datarate by one and retry the transmission. However, if the degraded datarate becomes insufficient to transmit the payload length, the attempt to retransmit will fail, and prior to this commit, the current code fails to fire the confirmation callback with the failure status, leaving the application code with no indication that the library will not retry the retransmission. Fixed in this commit by adding the payload-size-error condition check in order to fire the callback with failure indication.

Intended to fix https://github.com/beegee-tokyo/SX126x-Arduino/issues/86