### PR TITLE
fix: comparison between signed and unsigned integer in RAK11300 SimpleTimer

### DIFF
--- a/src/boards/mcu/rak11300/SimpleTimer.h
+++ b/src/boards/mcu/rak11300/SimpleTimer.h
@@ -111,7 +111,7 @@ private:
 	volatile timer_callback callbacks[MAX_TIMERS];
 
 	// delay values
-	volatile long delays[MAX_TIMERS];
+	volatile unsigned long delays[MAX_TIMERS];
 
 	// number of runs to be executed for each timer
 	volatile int maxNumRuns[MAX_TIMERS];


### PR DESCRIPTION
This fixes the following warnings:

```
./SX126x-Arduino/src/boards/mcu/rak11300/SimpleTimer.cpp: In member function 'void SimpleTimer::run()':
./SX126x-Arduino/src/boards/mcu/rak11300/SimpleTimer.cpp:67:40: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
    if (current_millis - prev_millis[i] >= delays[i])
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
./SX126x-Arduino/src/boards/mcu/rak11300/SimpleTimer.cpp: In member function 'bool SimpleTimer::check()':
./SX126x-Arduino/src/boards/mcu/rak11300/SimpleTimer.cpp:139:42: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
    if ((current_millis - prev_millis[i]) >= delays[i])
```