### PR TITLE
[Fix] Timer task creation assertion issue due to high priority

### DIFF
--- a/src/boards/mcu/rak11300/timer.cpp
+++ b/src/boards/mcu/rak11300/timer.cpp
@@ -128,7 +128,7 @@ void TimerConfig(void)
 	}
 
 	// Initialize the timer task
-	if (xTaskCreate(_timer_task, "TIMER", 4096, NULL, 8, &_timerTaskHandle))
+	if (xTaskCreate(_timer_task, "TIMER", 4096, NULL, configMAX_PRIORITIES - 1, &_timerTaskHandle))
 	{
 		LOG_LIB("TIM", "Timer task start success");
 	}


### PR DESCRIPTION

FreeRTOS checks for all task the priority and asserts that all of them are less than the maximum configured by the user. 

Currently, I'm using this [BSP](https://github.com/maxgerhardt/platform-raspberrypi?tab=readme-ov-file), which defines a max priority of 8... so I was experiencing failed assertion crash.

I just change priority to be the highest available to get rid of this problem in general.
