### PR TITLE
LORAWAN-OTAA-esp32-e22 example adapted for the EBYTE EoRa-S3-900TB

### DIFF
--- a/examples/LORAWAN-OTAA-eora-s3-900tb/.gitignore
+++ b/examples/LORAWAN-OTAA-eora-s3-900tb/.gitignore
@@ -1,0 +1,7 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch
+Generated
+Generated/*

--- a/examples/LORAWAN-OTAA-eora-s3-900tb/README.md
+++ b/examples/LORAWAN-OTAA-eora-s3-900tb/README.md
@@ -1,0 +1,5 @@
+LORAWAN OTAA EBYTE EoRa-S3-900TB for PlatformIO
+===    
+Example to be used with PlatformIO. This example is to show how to connect to the Helium network or TTN by OTAA activation. It is written only for the EoRa-S3-900TB : ESP32-S3 + E22-900MM22S (SX1262) + OLED display.
+
+See [E22 ESP32 example](../LORAWAN-OTAA-esp32-e22/) for configuration.

--- a/examples/LORAWAN-OTAA-eora-s3-900tb/boards/EoRa_PI_V1.json
+++ b/examples/LORAWAN-OTAA-eora-s3-900tb/boards/EoRa_PI_V1.json
@@ -1,0 +1,43 @@
+{
+    "build": {
+        "arduino": {
+            "ldscript": "esp32s3_out.ld",
+            "partitions": "default.csv",
+            "memory_type": "qio_qspi"
+        },
+        "core": "esp32",
+        "extra_flags": [
+            "-DBOARD_HAS_PSRAM",
+            "-DARDUINO_USB_CDC_ON_BOOT=1",
+            "-DARDUINO_RUNNING_CORE=1",
+            "-DARDUINO_EVENT_RUNNING_CORE=1"
+        ],
+        "f_cpu": "240000000L",
+        "f_flash": "80000000L",
+        "flash_mode": "qio",
+        "mcu": "esp32s3",
+        "variant": "esp32s3"
+    },
+    "connectivity": [
+        "wifi"
+    ],
+    "debug": {
+        "openocd_target": "esp32s3.cfg"
+    },
+    "frameworks": [
+        "arduino",
+        "espidf"
+    ],
+    "name": "EoRa PI",
+    "upload": {
+        "flash_size": "4MB",
+        "maximum_ram_size": 327680,
+        "maximum_size": 4194304,
+        "use_1200bps_touch": true,
+        "wait_for_upload_port": true,
+        "require_upload_port": true,
+        "speed": 921600
+    },
+    "url": "https://www.ebyte.com/",
+    "vendor": "EoRa"
+}

--- a/examples/LORAWAN-OTAA-eora-s3-900tb/include/README
+++ b/examples/LORAWAN-OTAA-eora-s3-900tb/include/README
@@ -1,0 +1,39 @@
+
+This directory is intended for project header files.
+
+A header file is a file containing C declarations and macro definitions
+to be shared between several project source files. You request the use of a
+header file in your project source file (C, C++, etc) located in `src` folder
+by including it, with the C preprocessing directive `#include'.
+
+```src/main.c
+
+#include "header.h"
+
+int main (void)
+{
+ ...
+}
+```
+
+Including a header file produces the same results as copying the header file
+into each source file that needs it. Such copying would be time-consuming
+and error-prone. With a header file, the related declarations appear
+in only one place. If they need to be changed, they can be changed in one
+place, and programs that include the header file will automatically use the
+new version when next recompiled. The header file eliminates the labor of
+finding and changing all the copies as well as the risk that a failure to
+find one copy will result in inconsistencies within a program.
+
+In C, the usual convention is to give header files names that end with `.h'.
+It is most portable to use only letters, digits, dashes, and underscores in
+header file names, and at most one dot.
+
+Read more about using header files in official GCC documentation:
+
+* Include Syntax
+* Include Operation
+* Once-Only Headers
+* Computed Includes
+
+https://gcc.gnu.org/onlinedocs/cpp/Header-Files.html

--- a/examples/LORAWAN-OTAA-eora-s3-900tb/platformio.ini
+++ b/examples/LORAWAN-OTAA-eora-s3-900tb/platformio.ini
@@ -1,0 +1,37 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+boards_dir = boards
+default_envs = esp32-s3
+
+[env:esp32-s3]
+platform = espressif32
+board = EoRa_PI_V1
+framework = arduino
+; upload_port = cu.usbserial-0001
+upload_speed = 921600
+monitor_speed = 115200
+monitor_rts = 0
+monitor_dtr = 0
+monitor_filters = 
+	default
+	esp32_exception_decoder
+build_flags = ${env.build_flags}
+	-DARDUINO_USB_MODE=1
+    -DARDUINO_USB_CDC_ON_BOOT=1
+    ;-UARDUINO_USB_CDC_ON_BOOT
+    ;-UARDUINO_USB_DFU_ON_BOOT
+    ;-UARDUINO_USB_MSC_ON_BOOT
+    -DCORE_DEBUG_LEVEL=1
+    -DLIB_DEBUG=0 ; set -DLIB_DEBUG=1 for Lorawan debug message
+lib_deps =
+    SX126x-Arduino
+    thingpulse/ESP8266 and ESP32 OLED driver for SSD1306 displays@^4.6.1

--- a/examples/LORAWAN-OTAA-eora-s3-900tb/src/main.cpp
+++ b/examples/LORAWAN-OTAA-eora-s3-900tb/src/main.cpp
@@ -1,0 +1,384 @@
+#include <Arduino.h>
+#include <LoRaWan-Arduino.h>
+#include <Wire.h>
+#include "SSD1306Wire.h"
+#include "utilities.h"
+
+// LoRaWan setup definitions
+#define SCHED_MAX_EVENT_DATA_SIZE APP_TIMER_SCHED_EVENT_DATA_SIZE // Maximum size of scheduler events
+#define SCHED_QUEUE_SIZE 60	// Maximum number of events in the scheduler queue
+
+/**< Maximum number of events in the scheduler queue  */
+#define LORAWAN_APP_DATA_BUFF_SIZE 256 // Size of the data to be transmitted
+#define LORAWAN_APP_TX_DUTYCYCLE 5000 // Defines the application data transmission duty cycle. 30s, value in [ms]
+#define APP_TX_DUTYCYCLE_RND 1000 // Defines a random delay for application data transmission duty cycle. 1s, value in [ms]
+#define JOINREQ_NBTRIALS 3	
+
+bool doOTAA = true;
+hw_config hwConfig;
+
+#ifdef ESP32
+
+// ESP32 - SX126x pin configuration
+int PIN_LORA_RESET = RADIO_RST_PIN;	 // LORA RESET
+int PIN_LORA_NSS = RADIO_CS_PIN;	 // LORA SPI CS
+int PIN_LORA_SCLK = RADIO_SCLK_PIN;	 // LORA SPI CLK
+int PIN_LORA_MISO = RADIO_MISO_PIN;	 // LORA SPI MISO
+int PIN_LORA_MOSI = RADIO_MOSI_PIN;	 // LORA SPI MOSI
+int PIN_LORA_BUSY = RADIO_BUSY_PIN;	 // LORA SPI BUSY
+int PIN_LORA_DIO_1 = RADIO_DIO1_PIN; // LORA DIO_1
+int RADIO_TXEN = -1;	 // LORA ANTENNA TX ENABLE
+int RADIO_RXEN = -1;	 // LORA ANTENNA RX ENABLE
+#endif
+
+// Define Helium or TTN OTAA keys. All msb (big endian).
+uint8_t nodeDeviceEUI[8] = {0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60};
+uint8_t nodeAppEUI[8] = {0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60};
+uint8_t nodeAppKey[16] = {0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x0F, 0xFD, 0x29, 0x8C, 0x51, 0x85, 0xF1, 0xB4};
+
+// Foward declaration
+/** LoRaWAN callback when join network finished */
+static void lorawan_has_joined_handler(void);
+/** LoRaWAN callback when join network failed */
+static void lorawan_join_fail_handler(void);
+/** LoRaWAN callback when data arrived */
+static void lorawan_rx_handler(lmh_app_data_t *app_data);
+/** LoRaWAN callback after class change request finished */
+static void lorawan_confirm_class_handler(DeviceClass_t Class);
+/** LoRaWAN callback after class change request finished */
+static void lorawan_unconfirm_tx_finished(void);
+/** LoRaWAN callback after class change request finished */
+static void lorawan_confirm_tx_finished(bool result);
+/** LoRaWAN Function to send a package */
+static void send_lora_frame(void);
+static uint32_t timers_init(void);
+
+// APP_TIMER_DEF(lora_tx_timer_id);	 // LoRa tranfer timer instance.
+TimerEvent_t appTimer;	 // LoRa tranfer timer instance.
+static uint8_t m_lora_app_data_buffer[LORAWAN_APP_DATA_BUFF_SIZE]; // Lora user application data buffer.
+static lmh_app_data_t m_lora_app_data = {m_lora_app_data_buffer, 0, 0, 0, 0};	 // Lora user application data structure.
+
+/**@brief Structure containing LoRaWan parameters, needed for lmh_init()
+ */
+static lmh_param_t lora_param_init = {LORAWAN_ADR_OFF, DR_3, LORAWAN_PUBLIC_NETWORK,
+										JOINREQ_NBTRIALS, LORAWAN_DEFAULT_TX_POWER, LORAWAN_DUTYCYCLE_OFF};
+
+static lmh_callback_t lora_callbacks = {BoardGetBatteryLevel, BoardGetUniqueId, BoardGetRandomSeed,
+										lorawan_rx_handler, lorawan_has_joined_handler, 
+										lorawan_confirm_class_handler, lorawan_join_fail_handler,
+										lorawan_unconfirm_tx_finished, lorawan_confirm_tx_finished};
+
+
+// Check if the board has an LED port defined
+#define LED_ON HIGH
+#define LED_OFF LOW
+#ifndef LED_BUILTIN
+#ifdef ESP32
+#define LED_BUILTIN 37
+#endif
+#endif
+
+SSD1306Wire display(0x3c, I2C_SDA, I2C_SCL);
+
+void join();
+	
+void ledOff(void)
+{
+	digitalWrite(LED_BUILTIN, LED_OFF);
+}
+
+void setup()
+{
+	pinMode(LED_BUILTIN, OUTPUT);
+	digitalWrite(LED_BUILTIN, LOW);
+
+	//OLED display
+	Wire.begin(I2C_SDA, I2C_SCL);
+	display.init();
+	display.flipScreenVertically();
+    display.setFont(ArialMT_Plain_10);
+	display.clear();
+	display.println("init...");
+	display.display();
+
+	// Define the HW configuration between MCU and SX126x
+	hwConfig.CHIP_TYPE = SX1262_CHIP;	// Example uses an eByte E22 module with an SX1262
+	hwConfig.PIN_LORA_RESET = PIN_LORA_RESET; // LORA RESET
+	hwConfig.PIN_LORA_NSS = PIN_LORA_NSS;	  // LORA SPI CS
+	hwConfig.PIN_LORA_SCLK = PIN_LORA_SCLK;	  // LORA SPI CLK
+	hwConfig.PIN_LORA_MISO = PIN_LORA_MISO;	  // LORA SPI MISO
+	hwConfig.PIN_LORA_DIO_1 = PIN_LORA_DIO_1; // LORA DIO_1
+	hwConfig.PIN_LORA_BUSY = PIN_LORA_BUSY;	  // LORA SPI BUSY
+	hwConfig.PIN_LORA_MOSI = PIN_LORA_MOSI;	  // LORA SPI MOSI
+	hwConfig.RADIO_TXEN = RADIO_TXEN;		// LORA ANTENNA TX ENABLE (e.g. eByte E22 module)
+	hwConfig.RADIO_RXEN = RADIO_RXEN;		// LORA ANTENNA RX ENABLE (e.g. eByte E22 module)
+	hwConfig.USE_DIO2_ANT_SWITCH = true;	// LORA DIO2 does control antenna, E22-900MMTB has a RF switch circuit
+	hwConfig.USE_DIO3_TCXO = false;			// LORA DIO3 controls oscillator voltage (e.g. eByte E22 module)
+	hwConfig.USE_DIO3_ANT_SWITCH = false;	// LORA DIO3 does not control antenna
+
+
+	// Initialize Serial for debug output
+	Serial.begin(115200);
+
+	Serial.println("=====================================");
+	Serial.println("SX126x LoRaWan test");
+	Serial.println("=====================================");
+
+	// Initialize LoRa chip.
+	uint32_t err_code = lora_hardware_init(hwConfig);
+	if (err_code != 0)
+	{
+		Serial.printf("lora_hardware_init failed - %d\n", err_code);
+	}
+
+	// Initialize Scheduler and timer (Must be after lora_hardware_init)
+	err_code = timers_init();
+	if (err_code != 0)
+	{
+		Serial.printf("timers_init failed - %d\n", err_code);
+	}
+
+	// Setup the EUIs and Keys
+	lmh_setDevEui(nodeDeviceEUI);
+	lmh_setAppEui(nodeAppEUI);
+	lmh_setAppKey(nodeAppKey);
+
+	// Initialize LoRaWan
+	// CLASS C works for esp32 and e22, US915 region works in america, other local frequencies can be found 
+	// here https://docs.helium.com/lorawan-on-helium/frequency-plans/
+	
+	err_code = lmh_init(&lora_callbacks, lora_param_init, doOTAA, CLASS_C, LORAMAC_REGION_US915);
+	if (err_code != 0)
+	{
+		Serial.printf("lmh_init failed - %d\n", err_code);
+	}
+
+	// For Helium and US915, you need as well to select subband 2 after you called lmh_init(), 
+	// For US816 you need to use subband 1. Other subbands configurations can be found in
+	// https://github.com/beegee-tokyo/SX126x-Arduino/blob/1c28c6e769cca2b7d699a773e737123fc74c47c7/src/mac/LoRaMacHelper.cpp
+
+	lmh_setSubBandChannels(2);
+
+	// Start Join procedure
+	join();
+}
+
+void loop()
+{
+	delay(50);
+}
+
+void join()
+{
+	display.print("Join ...");
+	display.display();
+	lmh_join();
+}
+
+static void lorawan_join_fail_handler(void)
+{
+	Serial.println("OTAA joined failed");
+	Serial.println("Check LPWAN credentials and if a gateway is in range");
+	// Restart Join procedure
+	Serial.println("Restart network join request");
+	display.println("failed");
+	display.display();
+	//Auto rejoin
+	join();
+}
+
+/**@brief LoRa function for handling HasJoined event.
+ */
+static void lorawan_has_joined_handler(void)
+{
+	display.println("success");
+	display.display();
+
+#if (OVER_THE_AIR_ACTIVATION != 0)
+	Serial.println("Network Joined");
+#else
+	Serial.println("OVER_THE_AIR_ACTIVATION != 0");
+
+#endif
+	lmh_class_request(CLASS_A);
+
+	TimerSetValue(&appTimer, LORAWAN_APP_TX_DUTYCYCLE);
+	TimerStart(&appTimer);
+	// app_timer_start(lora_tx_timer_id, APP_TIMER_TICKS(LORAWAN_APP_TX_DUTYCYCLE), NULL);
+	Serial.println("Sending frame");
+	send_lora_frame();
+}
+
+/**@brief Function for handling LoRaWan received data from Gateway
+ *
+ * @param[in] app_data  Pointer to rx data
+ */
+static void lorawan_rx_handler(lmh_app_data_t *app_data)
+{
+	display.printf("receive %d bytes\n", app_data->buffsize);
+	display.display();
+
+	Serial.printf("LoRa Packet received on port %d, size:%d, rssi:%d, snr:%d\n",
+				  app_data->port, app_data->buffsize, app_data->rssi, app_data->snr);
+
+	for (int i = 0; i < app_data->buffsize; i++)
+	{
+		Serial.printf("%0X ", app_data->buffer[i]);
+	}
+	Serial.println("");
+
+	switch (app_data->port)
+	{
+	case 3:
+		// Port 3 switches the class
+		if (app_data->buffsize == 1)
+		{
+			switch (app_data->buffer[0])
+			{
+			case 0:
+				lmh_class_request(CLASS_A);
+				break;
+
+			case 1:
+				lmh_class_request(CLASS_B);
+				break;
+
+			case 2:
+				lmh_class_request(CLASS_C);
+				break;
+
+			default:
+				break;
+			}
+		}
+		break;
+
+	case LORAWAN_APP_PORT:
+		// YOUR_JOB: Take action on received data
+		break;
+
+	default:
+		break;
+	}
+}
+
+/**@brief Function to confirm LORaWan class switch.
+ *
+ * @param[in] Class  New device class
+ */
+static void lorawan_confirm_class_handler(DeviceClass_t Class)
+{
+	Serial.printf("switch to class %c done\n", "ABC"[Class]);
+
+	// Informs the server that switch has occurred ASAP
+	m_lora_app_data.buffsize = 0;
+	m_lora_app_data.port = LORAWAN_APP_PORT;
+	lmh_send(&m_lora_app_data, LMH_UNCONFIRMED_MSG);
+}
+
+/**
+ * @brief Called after unconfirmed packet was sent
+ * 
+ */
+static void lorawan_unconfirm_tx_finished(void)
+{
+	display.println("Uncomfirmed TX finished");
+	display.display();
+
+	Serial.println("Uncomfirmed TX finished");
+}
+
+/**
+ * @brief Called after confirmed packet was sent
+ * @param result Result of sending true = ACK received false = No ACK
+ */
+static void lorawan_confirm_tx_finished(bool result)
+{
+	display.println("Comfirmed TX finished");
+	display.display();
+
+	Serial.printf("Comfirmed TX finished with result %s", result ? "ACK" : "NAK");
+}
+
+/**@brief Function for sending a LoRa package.
+ */
+static void send_lora_frame(void)
+{
+	display.println("Send");
+	display.display();
+
+	// Building the message to send
+	int32_t chipTemp = 0;
+	uint32_t i = 0;
+	Ticker ledTicker;
+
+	if (lmh_join_status_get() != LMH_SET)
+	{
+		// Not joined, try again later
+		Serial.println("Did not join network, skip sending frame");
+		return;
+	}
+
+	// Building the message to send
+
+	char t100 = (char)(chipTemp / 100);
+	char t10 = (char)((chipTemp - (t100 * 100)) / 10);
+	char t1 = (char)((chipTemp - (t100 * 100) - (t10 * 10)) / 1);
+
+	// Buffer contruction
+	m_lora_app_data.port = LORAWAN_APP_PORT;
+
+	m_lora_app_data.buffer[i++] = '{';
+	m_lora_app_data.buffer[i++] = '"';
+	m_lora_app_data.buffer[i++] = 'i';
+	m_lora_app_data.buffer[i++] = '"';
+	m_lora_app_data.buffer[i++] = ':';
+	m_lora_app_data.buffer[i++] = ',';
+	m_lora_app_data.buffer[i++] = '"';
+	m_lora_app_data.buffer[i++] = 'n';
+	m_lora_app_data.buffer[i++] = '"';
+	m_lora_app_data.buffer[i++] = ':';
+
+	m_lora_app_data.buffer[i++] = t100 + 0x30;
+	m_lora_app_data.buffer[i++] = t10 + 0x30;
+	m_lora_app_data.buffer[i++] = t1 + 0x30;
+	m_lora_app_data.buffer[i++] = '}';
+	m_lora_app_data.buffsize = i;
+
+	Serial.print("Data: ");
+	Serial.println((char *)m_lora_app_data.buffer);
+	Serial.print("Size: ");
+	Serial.println(m_lora_app_data.buffsize);
+	Serial.print("Port: ");
+	Serial.println(m_lora_app_data.port);
+
+	chipTemp += 1;
+	if (chipTemp >= 999)
+		chipTemp = 0;
+
+	lmh_error_status error = lmh_send(&m_lora_app_data, LMH_UNCONFIRMED_MSG);
+	if (error == LMH_SUCCESS)
+	{
+	}
+
+	Serial.printf("lmh_send result %d\n", error);
+	digitalWrite(LED_BUILTIN, LED_ON);
+	ledTicker.once(1, ledOff);
+}
+
+/**@brief Function for handling a LoRa tx timer timeout event.
+ */
+static void tx_lora_periodic_handler(void)
+{
+	TimerSetValue(&appTimer, LORAWAN_APP_TX_DUTYCYCLE);
+	TimerStart(&appTimer);
+	Serial.println("Sending frame");
+	send_lora_frame();
+}
+
+static uint32_t timers_init(void)
+{
+	appTimer.timerNum = 3;
+	TimerInit(&appTimer, tx_lora_periodic_handler);
+	return 0;
+}

--- a/examples/LORAWAN-OTAA-eora-s3-900tb/src/utilities.h
+++ b/examples/LORAWAN-OTAA-eora-s3-900tb/src/utilities.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#define UNUSE_PIN                   (-1)
+
+#define GPIO_PIN_16                 16
+#define GPIO_PIN_15                 15
+#define GPIO_PIN_RST                UNUSE_PIN
+#define GPIO_PIN_12                 12
+#define GPIO_PIN_48                 48
+#define GPIO_PIN_47                 47
+#define GPIO_PIN_35                 35
+#define GPIO_PIN_00                 BUTTON_PIN
+#define GPIO_PIN_36                 36
+#define GPIO_PIN_37                 BOARD_LED
+
+#define GPIO_PIN_38                 38
+#define GPIO_PIN_39                 39
+#define GPIO_PIN_40                 40
+#define GPIO_PIN_41                 41
+#define GPIO_PIN_45                 45
+#define GPIO_PIN_46                 46
+#define GPIO_PIN_42                 42
+
+#define I2C_SDA                     18
+#define I2C_SCL                     17
+#define OLED_RST                    UNUSE_PIN
+
+#define RADIO_SCLK_PIN              5
+#define RADIO_MISO_PIN              3
+#define RADIO_MOSI_PIN              6
+#define RADIO_CS_PIN                7
+#define RADIO_DIO1_PIN              33
+#define RADIO_BUSY_PIN              34
+#define RADIO_RST_PIN               8
+
+#define SDCARD_MOSI                 11
+#define SDCARD_MISO                 2
+#define SDCARD_SCLK                 14
+#define SDCARD_CS                   13
+
+#define BOARD_LED                   37
+#define LED_BUILTIN                 BOARD_LED
+#define LED_ON                      HIGH
+#define LED_OFF                     LOW
+
+#define BAT_ADC_PIN                 1
+#define BUTTON_PIN                  0
+
+#define HAS_SDCARD
+#define HAS_DISPLAY
+
+
+
+

--- a/examples/LORAWAN-OTAA-eora-s3-900tb/test/README
+++ b/examples/LORAWAN-OTAA-eora-s3-900tb/test/README
@@ -1,0 +1,11 @@
+
+This directory is intended for PlatformIO Unit Testing and project tests.
+
+Unit Testing is a software testing method by which individual units of
+source code, sets of one or more MCU program modules together with associated
+control data, usage procedures, and operating procedures, are tested to
+determine whether they are fit for use. Unit testing finds problems early
+in the development cycle.
+
+More information about PlatformIO Unit Testing:
+- https://docs.platformio.org/page/plus/unit-testing.html


### PR DESCRIPTION
The existing LORAWAN-OTAA-esp32-e22 example adapted for ESP32-S3 and E22-900MM22S lora module. "MM" version has a RF switch triggered by DIO2.
Some status are printed on the OLED display.